### PR TITLE
Add duel admin dashboard and navigation

### DIFF
--- a/duel.py
+++ b/duel.py
@@ -1,1 +1,21 @@
+"""Endpoints for duel administration pages."""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
 from model import *
+
+
+router = APIRouter()
+templates = Jinja2Templates(directory="templates")
+
+
+@router.get("/", response_class=HTMLResponse)
+async def duel_dashboard(request: Request):
+    """Render the duel admin dashboard."""
+    dict_all = {"duel_id": 0, "duel_month": []}
+    return templates.TemplateResponse(
+        "dashboard_duel.html", {"request": request, "dict_all": dict_all}
+    )
+

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from control.func_control_ai import get_update_list_trying_train, add_trying_to_
 from word import router as word_router
 
 from model import *
-from duel import *
+from duel import router as duel_router
 from func import (get_versions_main, get_versions_tt, get_trying_by_word, get_first_word_by_user,
                   check_word_facts, get_dict_fact)
 from graph import graph_vers_plotly, draw_graph_user, draw_graph_word, draw_distr_trying
@@ -30,6 +30,7 @@ from control.control_ai import check_control_al
 app = FastAPI()
 
 app.include_router(word_router, prefix="/word", tags=["Word"])
+app.include_router(duel_router, prefix="/duel", tags=["Duel"])
 
 # Подключение статики и шаблонизатора
 templates = Jinja2Templates(directory="templates")

--- a/static/duel_script.js
+++ b/static/duel_script.js
@@ -1,0 +1,8 @@
+function logout() {
+    window.location.href = '/logout';
+}
+
+document.getElementById('duels-back-btn').addEventListener('click', () => {
+    window.location.href = '/admin';
+});
+

--- a/static/script.js
+++ b/static/script.js
@@ -438,6 +438,11 @@ document.getElementById('word-fact-btn').addEventListener('click', async () => {
     }
 });
 
+// DUEL
+document.getElementById('duel-btn').addEventListener('click', () => {
+    window.open('/duel', '_blank');
+});
+
 
 document.getElementById('search-word').addEventListener('input', () => {
     const searchValue = document.getElementById('search-word').value.toLowerCase().trim();


### PR DESCRIPTION
## Summary
- add FastAPI router and template endpoint for duel admin dashboard
- wire duel router into application and open page from main dashboard
- add basic duel dashboard script with logout and back actions

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b98956c24c832f8d1eca8742112fb1