### PR TITLE
feat: add duel versions loader

### DIFF
--- a/static/duel_script.js
+++ b/static/duel_script.js
@@ -36,6 +36,9 @@ async function duelsByMonth(selectedMonth) {
 
                 listItem.title = `Начало: ${duel.start_time}\nКонец: ${duel.end_time}\nДлительность: ${duel.duration} минут`;
 
+                listItem.dataset.duelId = duel.id;
+                listItem.addEventListener('click', () => loadDuelVersions(duel.id));
+
                 duelList.appendChild(listItem);
             });
         } else {
@@ -50,4 +53,71 @@ document.getElementById('dropdown').addEventListener('change', function () {
     const selectedMonth = this.value;
     duelsByMonth(selectedMonth);
 });
+
+async function loadDuelVersions(duelId) {
+    try {
+        const sort = document.querySelector('input[name="duel-version-sort"]:checked').value;
+        const response = await fetch(`/duel/${duelId}/versions?sort=${sort}`);
+        if (!response.ok) throw new Error('Ошибка при загрузке данных');
+        const data = await response.json();
+
+        const header = document.getElementById('duel_vers-header');
+        header.setAttribute('data-duel-id', duelId);
+        const total = data.count_vers ?? data.count ?? (data.versions ? data.versions.length : 0);
+        if (data.duel_word) {
+            header.textContent = `Версии дуэли: ${data.duel_word} — Всего: ${total}`;
+        } else {
+            header.textContent = `Версии дуэли — Всего: ${total}`;
+        }
+
+        const list = document.getElementById('duel_vers-list');
+        list.innerHTML = '';
+        if (data.versions && data.versions.length > 0) {
+            data.versions.forEach((version, index) => {
+                const li = document.createElement('li');
+                li.textContent = version.text ?? '';
+                if (version.bg_color) {
+                    li.style.backgroundColor = version.bg_color;
+                } else {
+                    setBgItem(index, li);
+                }
+
+                const isSecond = version.second_player || version.is_second || version.player === 2 || version.player_idx === 2;
+                if (isSecond) {
+                    li.classList.add('second-player');
+                }
+                list.appendChild(li);
+            });
+        } else {
+            list.innerHTML = '<li>Нет версий для данной дуэли</li>';
+        }
+    } catch (error) {
+        console.error('Ошибка:', error);
+    }
+}
+
+document.querySelectorAll('input[name="duel-version-sort"]').forEach(radio => {
+    radio.addEventListener('change', () => {
+        const duelId = document.getElementById('duel_vers-header').getAttribute('data-duel-id');
+        if (duelId) {
+            loadDuelVersions(duelId);
+        }
+    });
+});
+
+function setBgItem(index, listItem) {
+    if (index >= 5000) {
+        listItem.style.backgroundColor = '#f4bcfe';
+    } else if (index >= 2500 && index < 5000) {
+        listItem.style.backgroundColor = '#aad5ff';
+    } else if (index >= 500 && index < 2500) {
+        listItem.style.backgroundColor = '#d6ffab';
+    } else if (index >= 100 && index < 500) {
+        listItem.style.backgroundColor = '#ffffbf';
+    } else if (index >= 20 && index < 100) {
+        listItem.style.backgroundColor = '#ffc673';
+    } else if (index >= 0 && index < 20) {
+        listItem.style.backgroundColor = '#ff9f98';
+    }
+}
 


### PR DESCRIPTION
## Summary
- store duel ids on duel list items and load versions on click
- fetch and render duel versions with sorting and background coloring
- reload versions on sort change and include helper for default colors

## Testing
- `node --check static/duel_script.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba7bef706c832fbb17872ff846e406