### PR TITLE
style: add second-player class for duel versions

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -391,3 +391,7 @@ input[type="radio"] + label:hover::before {
   flex-direction: column;
   gap: 10px;
 }
+
+.second-player {
+  margin-left: 20px;
+}


### PR DESCRIPTION
## Summary
- add `.second-player` CSS class to shift second player's versions
- existing duel script already applies this class to second player's entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba7df01e48832fb4fb7617ea6154d1