### PR TITLE
Fix duel versions fetch URL

### DIFF
--- a/static/duel_script.js
+++ b/static/duel_script.js
@@ -57,7 +57,7 @@ document.getElementById('dropdown').addEventListener('change', function () {
 async function loadDuelVersions(duelId) {
     try {
         const sort = document.querySelector('input[name="duel-version-sort"]:checked').value;
-        const response = await fetch(`/duel/${duelId}/versions?sort=${sort}`);
+        const response = await fetch(`/duel/versions/${duelId}?sort=${sort}`);
         if (!response.ok) throw new Error('Ошибка при загрузке данных');
         const data = await response.json();
 


### PR DESCRIPTION
## Summary
- align duel versions fetch URL with backend route `/duel/versions/{duel_id}`

## Testing
- `pytest`
- `uvicorn main:app --port 8000` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba80be2260832fb8a15e9070e45d90