### PR TITLE
Display duel version indices and rank delta

### DIFF
--- a/duel.py
+++ b/duel.py
@@ -150,8 +150,10 @@ async def get_duel_versions(duel_id: int, sort: str = "time"):
             {
                 "user_id": user.id,
                 "text": dv.text,
-                "idx": dv.idx_global,
-                "ts": dv.ts.isoformat(),
+                "idx_global": dv.idx_global,
+                "idx_personal": dv.idx_personal,
+                "delta_rank": dv.delta_rank,
+                "ts": dv.ts.isoformat() if dv.ts else None,
                 "player": player_map.get(dv.user_id),
                 "bg_color": get_bg_color(dv.idx_global),
             }

--- a/static/duel_script.js
+++ b/static/duel_script.js
@@ -75,7 +75,11 @@ async function loadDuelVersions(duelId) {
         if (data.versions && data.versions.length > 0) {
             data.versions.forEach((version, index) => {
                 const li = document.createElement('li');
-                li.textContent = version.text ?? '';
+                let text = `${version.idx_personal ?? index + 1}. ${version.text ?? ''} ✏️${version.idx_global ?? ''}`;
+                if (version.delta_rank && version.delta_rank > 0) {
+                    text += ` - 🍀${version.delta_rank}`;
+                }
+                li.textContent = text;
                 if (version.bg_color) {
                     li.style.backgroundColor = version.bg_color;
                 } else {


### PR DESCRIPTION
## Summary
- return idx_global, idx_personal and delta_rank from duel version API
- render duel version entries with global and personal indices and optional rank delta

## Testing
- `python -m py_compile duel.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba7a26e868832fb1fd37fbb60b4a04