### PR TITLE
Display duel details

### DIFF
--- a/static/duel_script.js
+++ b/static/duel_script.js
@@ -64,10 +64,24 @@ async function loadDuelVersions(duelId) {
         const header = document.getElementById('duel_vers-header');
         header.dataset.duelId = duelId;
         const total = data.count_vers ?? data.count ?? (data.versions ? data.versions.length : 0);
-        if (data.duel_word) {
-            header.textContent = `Версии дуэли: ${data.duel_word} — Всего: ${total}`;
+        if (data.word) {
+            header.textContent = `Версии дуэли: ${data.word} — Всего: ${total}`;
         } else {
             header.textContent = `Версии дуэли — Всего: ${total}`;
+        }
+
+        const infoBlock = document.getElementById('duel-info');
+        if (infoBlock) {
+            const lines = [];
+            if (data.word) lines.push(`🖋 ${data.word}`); // 🖋
+            if (data.date) lines.push(`📅 ${data.date}`); // 📅
+            lines.push(`🕛 ${data.start_time || ''} / 🏁 ${data.end_time || ''}`); // 🕛 / 🏁
+            if (Array.isArray(data.participants)) {
+                data.participants.forEach(p => {
+                    lines.push(`👥 ${p.name} (${p.version_count})${data.winner_id === p.id ? ' 👑' : ''}`); // 👥 ... 👑
+                });
+            }
+            infoBlock.innerHTML = lines.map(l => `<div>${l}</div>`).join('');
         }
 
         const list = document.getElementById('duel_vers-list');

--- a/static/style.css
+++ b/static/style.css
@@ -136,6 +136,14 @@ li div {
     display: block;
 }
 
+#duel-info {
+    margin-bottom: 10px;
+}
+
+#duel-info div {
+    margin: 2px 0;
+}
+
 .word-item {
     cursor: pointer;
     padding: 10px;

--- a/templates/dashboard_duel.html
+++ b/templates/dashboard_duel.html
@@ -69,6 +69,7 @@
         </div>
         <div class="column">
             <h2 id="duel_vers-header">Версии дуэли</h2>
+            <div id="duel-info"></div>
             <ul id="duel_vers-list">
 
             </ul>


### PR DESCRIPTION
## Summary
- Add duel info container on dashboard to show metadata and participants
- Extend duel versions API to return word, timings, winner and participant stats
- Render duel details on client side with emoji labels and basic styling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba8fab1310832fba675a382e682533