### PR TITLE
Add duel version graph button handler

### DIFF
--- a/static/duel_script.js
+++ b/static/duel_script.js
@@ -124,6 +124,17 @@ document.querySelectorAll('input[name="duel-version-sort"]').forEach((radio) => 
     });
 });
 
+document.getElementById('duel-version-graph-btn').addEventListener('click', async () => {
+    const duelId = document.getElementById('duel_vers-header').dataset.duelId;
+
+    try {
+        window.open(`/duel/graph_vers/${duelId}`, '_blank');
+    } catch (error) {
+        console.error('Ошибка:', error);
+        alert('Не удалось загрузить график');
+    }
+});
+
 function setBgItem(index, listItem) {
     if (index >= 5000) {
         listItem.style.backgroundColor = '#f4bcfe';


### PR DESCRIPTION
## Summary
- Add event listener for `#duel-version-graph-btn` to open duel versions graph in a new tab with error handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba92d44394832f823ff3988c31d9f7