### PR TITLE
Use log scale for duel graph indices

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -32,8 +32,9 @@ async def graph_duel_versions_plotly(duel):
 
     data = {name: {"x": [], "y": [], "text": []} for name in players}
     for dv, name in rows:
+        idx = dv.idx_global if dv.idx_global > 0 else 1
         data[name]["x"].append(dv.ts)
-        data[name]["y"].append(dv.idx_global)
+        data[name]["y"].append(idx)
         data[name]["text"].append(dv.text)
 
     fig = make_subplots(rows=2, cols=1, shared_xaxes=True)
@@ -67,6 +68,8 @@ async def graph_duel_versions_plotly(duel):
             row=2,
             col=1,
         )
+    fig.update_yaxes(type="log", row=1, col=1)
+    fig.update_yaxes(type="log", row=2, col=1)
 
     return fig.to_html(full_html=True, include_plotlyjs="cdn")
 


### PR DESCRIPTION
## Summary
- Avoid log plotting issues by clamping non-positive indices to 1 in duel version graphs
- Display duel version indices on logarithmic y-axes for both scatter and line subplots

## Testing
- `python -m py_compile graph.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba95ffe244832f8708a9e8a88ad994