### PR TITLE
Simplify duel version plot

### DIFF
--- a/duel.py
+++ b/duel.py
@@ -11,6 +11,7 @@ from fastapi.templating import Jinja2Templates
 
 from model import *
 from func import get_bg_color
+from graph import graph_duel_versions_plotly
 
 
 router = APIRouter()
@@ -232,5 +233,15 @@ async def get_duel_versions(duel_id: int, sort: str = "time"):
         ]
 
     return JSONResponse(content={**duel_info, "versions": versions})
+
+
+@router.get("/graph_vers/{duel_id}", response_class=HTMLResponse)
+async def duel_versions_graph(duel_id: int):
+    async with get_session() as session:
+        duel = await session.get(Duel, duel_id)
+    if not duel:
+        return HTMLResponse(content="Duel not found", status_code=404)
+    html = await graph_duel_versions_plotly(duel)
+    return HTMLResponse(content=html)
 
 

--- a/graph.py
+++ b/graph.py
@@ -11,6 +11,53 @@ from func import get_username
 from model import *
 
 
+async def graph_duel_versions_plotly(duel):
+    """Generate HTML for duel versions graph using Plotly."""
+    async with get_session() as session:
+        result = await session.execute(
+            select(DuelVersion, User.username)
+            .join(User, DuelVersion.user_id == User.id)
+            .filter(DuelVersion.duel_id == duel.id)
+            .order_by(DuelVersion.ts)
+        )
+        rows = result.all()
+
+    players = []
+    for _, name in rows:
+        if name not in players:
+            players.append(name)
+
+    colors = ["blue", "red"]
+    color_map = {name: colors[i % len(colors)] for i, name in enumerate(players)}
+
+    data = {name: {"x": [], "y": [], "text": []} for name in players}
+    for dv, name in rows:
+        data[name]["x"].append(dv.ts)
+        data[name]["y"].append(dv.idx_global)
+        data[name]["text"].append(dv.text)
+
+    fig = go.Figure()
+
+    for name in players:
+        color = color_map.get(name, "blue")
+        y_vals = [y if y > 0 else 1 for y in data[name]["y"]]
+        fig.add_trace(
+            go.Scatter(
+                x=data[name]["x"],
+                y=y_vals,
+                mode="lines+markers",
+                marker=dict(color=color),
+                line=dict(color=color),
+                name=name,
+                text=data[name]["text"],
+                hovertemplate="Слово: %{text}<br>Индекс: %{y}<br>Игрок: " + name,
+            )
+        )
+
+    fig.update_yaxes(type="log")
+    return fig.to_html(full_html=True, include_plotlyjs="cdn")
+
+
 async def graph_vers_plotly(trying):
     # Получение данных из базы данных
     async with get_session() as session:


### PR DESCRIPTION
## Summary
- show duel version indices as two colored traces on a single plot
- apply logarithmic scaling to the Y axis and guard against non-positive values

## Testing
- `python -m py_compile graph.py duel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba93a234b8832f9c2912670f9039e4