### PR TITLE
Add admin neuron top-up action (💰) with amount spinbox

### DIFF
--- a/main.py
+++ b/main.py
@@ -393,6 +393,51 @@ async def set_user_alpha(trying_id):
         raise HTTPException(status_code=500, detail=str(e))
 
 
+class UserTransactionCreate(BaseModel):
+    amount: int
+
+
+
+
+@app.post("/user_transaction/{trying_id}")
+async def create_user_transaction(trying_id: int, payload: UserTransactionCreate):
+    if payload.amount <= 0:
+        raise HTTPException(status_code=400, detail="Amount must be greater than 0")
+
+    async with get_session() as session:
+        result_t = await session.execute(select(Trying).filter_by(id=trying_id))
+        trying = result_t.scalar_one_or_none()
+
+        if not trying:
+            raise HTTPException(status_code=404, detail="Trying not found")
+
+        result_uc = await session.execute(select(UserCoin).filter_by(user_id=trying.user_id))
+        user_coin = result_uc.scalar_one_or_none()
+
+        if not user_coin:
+            user_coin = UserCoin(user_id=trying.user_id, coin=0)
+            session.add(user_coin)
+            await session.flush()
+
+        user_coin.coin += payload.amount
+
+        trans = UserTransaction(
+            user_id=trying.user_id,
+            amount=payload.amount,
+            description='admin add neurons',
+            date_trans=datetime.datetime.now()
+        )
+        session.add(trans)
+
+        return {
+            "message": "Transaction created",
+            "user_id": trying.user_id,
+            "trying_id": trying_id,
+            "amount": payload.amount,
+            "balance": user_coin.coin
+        }
+
+
 class WordContextUpdate(BaseModel):
     order: List[dict]
 

--- a/static/script.js
+++ b/static/script.js
@@ -714,6 +714,49 @@ document.getElementById('first-words-btn').addEventListener('click', async () =>
     }
 });
 
+
+
+document.getElementById('user-transactions-btn').addEventListener('click', async () => {
+    const tryingId = document.getElementById('version-header').getAttribute('data-trying-id');
+    if (!tryingId) {
+        alert('Выберите пользователя');
+        return;
+    }
+
+    const amountInput = document.getElementById('neurons-amount-input');
+    const amount = parseInt(amountInput?.value, 10);
+
+    if (Number.isNaN(amount) || amount <= 0) {
+        alert('Укажите корректное количество нейронов');
+        return;
+    }
+
+    try {
+        const response = await fetch(`/user_transaction/${tryingId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ amount }),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data?.detail || 'Не удалось начислить нейроны');
+        }
+
+        alert(`Начислено ${data.amount} нейронов. Баланс: ${data.balance}`);
+
+        const wordId = document.getElementById('trying-header').getAttribute('data-word-id');
+        if (wordId) {
+            await onWordClick(wordId, 0);
+        }
+    } catch (error) {
+        console.error('Ошибка начисления нейронов:', error);
+        alert(error.message || 'Не удалось начислить нейроны');
+    }
+});
 document.getElementById('reset-ai-btn').addEventListener('click', async () => {
     const header = document.getElementById('trying-header');
     const wordId = header.getAttribute('data-word-id');

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -118,6 +118,7 @@
                 <button id="graph-vers-btn">📉</button>
                 <button id="graph-user-btn">📊</button>
                 <button id="first-words-btn">👀</button>
+                <input id="neurons-amount-input" type="number" min="1" step="1" value="1" title="Количество нейронов" style="width: 56px;">
                 <button id="user-transactions-btn">💰</button>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Provide admins a quick way to credit "нейроны" to a selected user from the dashboard using the existing 💰 control. 
- Allow specifying the amount to add via a spinbox to avoid manual backend steps. 
- Ensure the UI updates after the operation so the trying list and balances reflect the change immediately. 

### Description
- Added a spinbox input `#neurons-amount-input` next to the `#user-transactions-btn` in `templates/dashboard.html` to specify the number of neurons to add. 
- Implemented a frontend handler in `static/script.js` that validates the selected user and positive amount, sends a `POST` to `/user_transaction/{trying_id}`, shows the result, and refreshes the trying list via `onWordClick`. 
- Added a backend `POST /user_transaction/{trying_id}` endpoint in `main.py` and a `UserTransactionCreate` Pydantic model to accept `{ amount: int }`, resolve `Trying` → `User`, create a `UserCoin` row if missing, increment the user's coin balance, and insert a `UserTransaction` record with `description='admin add neurons'`. 
- The endpoint returns the created transaction details and the updated `balance` for client display. 

### Testing
- Compiled the main modules with `python -m compileall main.py func.py word.py duel.py auth.py` and the compilation completed successfully. 
- Attempted to start/import the app (`import main`) for runtime verification but execution failed due to missing runtime dependency `fastapi` (`ModuleNotFoundError: fastapi`). 
- No automated unit tests were added; feature validated by static checks and local code compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a467984960832f954be3c3a10f7ccc)