### PR TITLE
Add context word move action

### DIFF
--- a/main.py
+++ b/main.py
@@ -446,6 +446,11 @@ class WordContextDelete(BaseModel):
     index: int
 
 
+class WordContextMove(BaseModel):
+    from_index: int
+    to_index: int
+
+
 @app.post("/update-context/{word_id}")
 async def update_context(word_id: int, context: WordContextUpdate):
     new_context = [i["word_text"].split('. ')[1] for i in context.order]
@@ -483,6 +488,32 @@ async def delete_context_item(word_id: int, payload: WordContextDelete):
         "context": context_list,
     }
 
+
+@app.post("/move-context/{word_id}")
+async def move_context_item(word_id: int, payload: WordContextMove):
+    word_id = int(word_id)
+    async with get_session() as session:
+        word = await session.get(Word, word_id)
+        if not word:
+            raise HTTPException(status_code=404, detail="Word not found")
+
+        context_list = json.loads(word.context)
+
+        if payload.from_index < 0 or payload.from_index >= len(context_list):
+            raise HTTPException(status_code=400, detail="Source context index out of range")
+
+        if payload.to_index < 0 or payload.to_index >= len(context_list):
+            raise HTTPException(status_code=400, detail="Target context index out of range")
+
+        moved_item = context_list.pop(payload.from_index)
+        context_list.insert(payload.to_index, moved_item)
+        word.context = json.dumps(context_list)
+
+    return {
+        "message": f"Context item moved from {payload.from_index} to {payload.to_index} for word {word_id}",
+        "moved": moved_item,
+        "context": context_list,
+    }
 
 @app.get("/trying/control_ai/{trying_id}")
 async def get_control_ai(trying_id):

--- a/static/script.js
+++ b/static/script.js
@@ -357,6 +357,92 @@ async function handleRemoveContextWordClick() {
     }
 }
 
+async function handleMoveContextWordClick() {
+    try {
+        const wordHeader = document.getElementById('word-header');
+        if (!wordHeader) {
+            return;
+        }
+
+        const wordId = wordHeader.getAttribute('data-word-id');
+        if (!wordId) {
+            alert('Выберите слово для изменения контекста');
+            return;
+        }
+
+        const orderInput = document.getElementById('word-order-input');
+        if (!orderInput) {
+            return;
+        }
+
+        const fromIndex = parseInt(orderInput.value, 10);
+        if (Number.isNaN(fromIndex) || fromIndex < 0) {
+            alert('Укажите корректный текущий номер элемента контекста');
+            return;
+        }
+
+        const contextItems = document.querySelectorAll('#word-list li.word-item');
+        if (contextItems.length === 0) {
+            alert('Контекст выбранного слова пуст');
+            return;
+        }
+
+        if (fromIndex >= contextItems.length) {
+            alert(`Текущая позиция должна быть от 0 до ${contextItems.length - 1}`);
+            return;
+        }
+
+        const targetValue = window.prompt(
+            `На какую позицию переместить слово контекста? Укажите номер от 0 до ${contextItems.length - 1}.`,
+            String(fromIndex)
+        );
+        if (targetValue === null) {
+            return;
+        }
+
+        const toIndex = parseInt(targetValue, 10);
+        if (Number.isNaN(toIndex) || toIndex < 0 || toIndex >= contextItems.length) {
+            alert(`Укажите корректную новую позицию от 0 до ${contextItems.length - 1}`);
+            return;
+        }
+
+        if (toIndex === fromIndex) {
+            return;
+        }
+
+        const response = await fetch(`/move-context/${wordId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ from_index: fromIndex, to_index: toIndex }),
+        });
+
+        const data = await response.json();
+        if (!response.ok) {
+            const detailMessage = typeof data === 'object' && data !== null ? data.detail : null;
+            throw new Error(detailMessage || 'Ошибка при перемещении элемента контекста');
+        }
+
+        orderInput.value = toIndex;
+
+        const selectedMonth = document.getElementById('dropdown')?.value;
+        if (selectedMonth === 'new') {
+            await onNewWordClick(Number(wordId));
+        } else {
+            await onWordClick(Number(wordId), 1);
+        }
+    } catch (error) {
+        console.error('Ошибка при перемещении слова в контексте:', error);
+        alert(error.message || 'Не удалось переместить слово в контексте');
+    }
+}
+
+const moveContextWordBtn = document.getElementById('move-context-word-btn');
+if (moveContextWordBtn) {
+    moveContextWordBtn.addEventListener('click', handleMoveContextWordClick);
+}
+
 const removeContextWordBtn = document.getElementById('remove-context-word-btn');
 if (removeContextWordBtn) {
     removeContextWordBtn.addEventListener('click', handleRemoveContextWordClick);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -72,6 +72,7 @@
                 <input id="word-order-input" type="number" min="0" max="100" step="1" value="50">
             </div>
             <div class="btn-container">
+                <button id="move-context-word-btn" title="Переместить слово контекста на указанную позицию">🎯</button>
                 <button id="remove-context-word-btn" title="Удалить из контекста">🥊</button>
                 <button id="delete-word-btn" title="Удалить слово">❌</button>
                 <button id="move-word-btn">🔀</button>


### PR DESCRIPTION
### Motivation
- Improve UX for reordering distant context items by adding an explicit action to move a single context word to a specified position.

### Description
- Added a 🎯 button in `templates/dashboard.html` placed before the existing remove-from-context button to trigger the move action. 
- Implemented client-side handler in `static/script.js` that reads the current position from the spinbox `word-order-input`, prompts for a target position, validates bounds, sends `POST /move-context/{word_id}` and refreshes the displayed context. 
- Added a server endpoint `POST /move-context/{word_id}` and a `WordContextMove` Pydantic model in `main.py` which validate `from_index`/`to_index`, move the item inside `Word.context` (JSON) and persist the new order. 

### Testing
- Compiled the server file with `python3 -m py_compile main.py` and it completed successfully. 
- Ran `git diff --check` to validate diffs and there were no check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5491828e04832f9f02b4ee1119f14c)