### PR TITLE
Add edit and move operations for word context with UI controls

### DIFF
--- a/main.py
+++ b/main.py
@@ -446,6 +446,16 @@ class WordContextDelete(BaseModel):
     index: int
 
 
+class WordContextMove(BaseModel):
+    from_index: int
+    to_index: int
+
+
+class WordContextEdit(BaseModel):
+    index: int
+    word: str
+
+
 @app.post("/update-context/{word_id}")
 async def update_context(word_id: int, context: WordContextUpdate):
     new_context = [i["word_text"].split('. ')[1] for i in context.order]
@@ -483,6 +493,60 @@ async def delete_context_item(word_id: int, payload: WordContextDelete):
         "context": context_list,
     }
 
+
+@app.post("/edit-context/{word_id}")
+async def edit_context_item(word_id: int, payload: WordContextEdit):
+    word_id = int(word_id)
+    async with get_session() as session:
+        word = await session.get(Word, word_id)
+        if not word:
+            raise HTTPException(status_code=404, detail="Word not found")
+
+        context_list = json.loads(word.context)
+
+        if payload.index < 0 or payload.index >= len(context_list):
+            raise HTTPException(status_code=400, detail="Context index out of range")
+
+        edited_item = payload.word.strip()
+        if not edited_item:
+            raise HTTPException(status_code=400, detail="Context word cannot be empty")
+
+        previous_item = context_list[payload.index]
+        context_list[payload.index] = edited_item
+        word.context = json.dumps(context_list)
+
+    return {
+        "message": f"Context item {payload.index} edited for word {word_id}",
+        "previous": previous_item,
+        "edited": edited_item,
+        "context": context_list,
+    }
+
+@app.post("/move-context/{word_id}")
+async def move_context_item(word_id: int, payload: WordContextMove):
+    word_id = int(word_id)
+    async with get_session() as session:
+        word = await session.get(Word, word_id)
+        if not word:
+            raise HTTPException(status_code=404, detail="Word not found")
+
+        context_list = json.loads(word.context)
+
+        if payload.from_index < 0 or payload.from_index >= len(context_list):
+            raise HTTPException(status_code=400, detail="Source context index out of range")
+
+        if payload.to_index < 0 or payload.to_index >= len(context_list):
+            raise HTTPException(status_code=400, detail="Target context index out of range")
+
+        moved_item = context_list.pop(payload.from_index)
+        context_list.insert(payload.to_index, moved_item)
+        word.context = json.dumps(context_list)
+
+    return {
+        "message": f"Context item moved from {payload.from_index} to {payload.to_index} for word {word_id}",
+        "moved": moved_item,
+        "context": context_list,
+    }
 
 @app.get("/trying/control_ai/{trying_id}")
 async def get_control_ai(trying_id):

--- a/static/script.js
+++ b/static/script.js
@@ -357,6 +357,177 @@ async function handleRemoveContextWordClick() {
     }
 }
 
+async function handleMoveContextWordClick() {
+    try {
+        const wordHeader = document.getElementById('word-header');
+        if (!wordHeader) {
+            return;
+        }
+
+        const wordId = wordHeader.getAttribute('data-word-id');
+        if (!wordId) {
+            alert('Выберите слово для изменения контекста');
+            return;
+        }
+
+        const orderInput = document.getElementById('word-order-input');
+        if (!orderInput) {
+            return;
+        }
+
+        const fromIndex = parseInt(orderInput.value, 10);
+        if (Number.isNaN(fromIndex) || fromIndex < 0) {
+            alert('Укажите корректный текущий номер элемента контекста');
+            return;
+        }
+
+        const contextItems = document.querySelectorAll('#word-list li.word-item');
+        if (contextItems.length === 0) {
+            alert('Контекст выбранного слова пуст');
+            return;
+        }
+
+        if (fromIndex >= contextItems.length) {
+            alert(`Текущая позиция должна быть от 0 до ${contextItems.length - 1}`);
+            return;
+        }
+
+        const targetValue = window.prompt(
+            `На какую позицию переместить слово контекста? Укажите номер от 0 до ${contextItems.length - 1}.`,
+            String(fromIndex)
+        );
+        if (targetValue === null) {
+            return;
+        }
+
+        const toIndex = parseInt(targetValue, 10);
+        if (Number.isNaN(toIndex) || toIndex < 0 || toIndex >= contextItems.length) {
+            alert(`Укажите корректную новую позицию от 0 до ${contextItems.length - 1}`);
+            return;
+        }
+
+        if (toIndex === fromIndex) {
+            return;
+        }
+
+        const response = await fetch(`/move-context/${wordId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ from_index: fromIndex, to_index: toIndex }),
+        });
+
+        const data = await response.json();
+        if (!response.ok) {
+            const detailMessage = typeof data === 'object' && data !== null ? data.detail : null;
+            throw new Error(detailMessage || 'Ошибка при перемещении элемента контекста');
+        }
+
+        orderInput.value = toIndex;
+
+        const selectedMonth = document.getElementById('dropdown')?.value;
+        if (selectedMonth === 'new') {
+            await onNewWordClick(Number(wordId));
+        } else {
+            await onWordClick(Number(wordId), 1);
+        }
+    } catch (error) {
+        console.error('Ошибка при перемещении слова в контексте:', error);
+        alert(error.message || 'Не удалось переместить слово в контексте');
+    }
+}
+
+const moveContextWordBtn = document.getElementById('move-context-word-btn');
+if (moveContextWordBtn) {
+    moveContextWordBtn.addEventListener('click', handleMoveContextWordClick);
+}
+
+async function handleEditContextWordClick() {
+    try {
+        const wordHeader = document.getElementById('word-header');
+        if (!wordHeader) {
+            return;
+        }
+
+        const wordId = wordHeader.getAttribute('data-word-id');
+        if (!wordId) {
+            alert('Выберите слово для изменения контекста');
+            return;
+        }
+
+        const orderInput = document.getElementById('word-order-input');
+        if (!orderInput) {
+            return;
+        }
+
+        const contextIndex = parseInt(orderInput.value, 10);
+        if (Number.isNaN(contextIndex) || contextIndex < 0) {
+            alert('Укажите корректный номер элемента контекста');
+            return;
+        }
+
+        const contextItems = document.querySelectorAll('#word-list li.word-item');
+        if (contextItems.length === 0) {
+            alert('Контекст выбранного слова пуст');
+            return;
+        }
+
+        if (contextIndex >= contextItems.length) {
+            alert(`Позиция для редактирования должна быть от 0 до ${contextItems.length - 1}`);
+            return;
+        }
+
+        const currentText = contextItems[contextIndex].textContent.replace(/^\d+\.\s*/, '');
+        const editedValue = window.prompt(
+            `Отредактируйте слово контекста на позиции ${contextIndex}.`,
+            currentText
+        );
+        if (editedValue === null) {
+            return;
+        }
+
+        const editedWord = editedValue.trim();
+        if (!editedWord) {
+            alert('Слово контекста не может быть пустым');
+            return;
+        }
+
+        if (editedWord === currentText) {
+            return;
+        }
+
+        const response = await fetch(`/edit-context/${wordId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ index: contextIndex, word: editedWord }),
+        });
+
+        const data = await response.json();
+        if (!response.ok) {
+            const detailMessage = typeof data === 'object' && data !== null ? data.detail : null;
+            throw new Error(detailMessage || 'Ошибка при редактировании элемента контекста');
+        }
+
+        const selectedMonth = document.getElementById('dropdown')?.value;
+        if (selectedMonth === 'new') {
+            await onNewWordClick(Number(wordId));
+        } else {
+            await onWordClick(Number(wordId), 1);
+        }
+    } catch (error) {
+        console.error('Ошибка при редактировании слова в контексте:', error);
+        alert(error.message || 'Не удалось отредактировать слово в контексте');
+    }
+}
+
+const editContextWordBtn = document.getElementById('edit-context-word-btn');
+if (editContextWordBtn) {
+    editContextWordBtn.addEventListener('click', handleEditContextWordClick);
+}
+
 const removeContextWordBtn = document.getElementById('remove-context-word-btn');
 if (removeContextWordBtn) {
     removeContextWordBtn.addEventListener('click', handleRemoveContextWordClick);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -72,6 +72,8 @@
                 <input id="word-order-input" type="number" min="0" max="100" step="1" value="50">
             </div>
             <div class="btn-container">
+                <button id="move-context-word-btn" title="Переместить слово контекста на указанную позицию">🎯</button>
+                <button id="edit-context-word-btn" title="Редактировать слово контекста по указанной позиции">✏️</button>
                 <button id="remove-context-word-btn" title="Удалить из контекста">🥊</button>
                 <button id="delete-word-btn" title="Удалить слово">❌</button>
                 <button id="move-word-btn">🔀</button>


### PR DESCRIPTION
### Motivation

- Provide the ability to reorder and edit individual context items for a Word without replacing the whole context list.
- Improve the dashboard UI so admins can move or edit a specific context entry by index.

### Description

- Added Pydantic models `WordContextMove` and `WordContextEdit` and implemented new endpoints `POST /move-context/{word_id}` and `POST /edit-context/{word_id}` to move and edit context items respectively, including index validation and helpful error responses.
- Implemented server-side logic to update `Word.context` JSON when items are moved or edited and return the previous and new values in responses.
- Added client-side handlers `handleMoveContextWordClick` and `handleEditContextWordClick` in `static/script.js` to prompt the user for indices/values, call the new endpoints, and refresh the word view; included input validation and user-facing error messages.
- Updated `templates/dashboard.html` to add two new buttons (`move-context-word-btn` and `edit-context-word-btn`) and wired the new handlers to these buttons.

### Testing

- Ran the project's automated test suite using `pytest` and all tests completed successfully.
- No new automated tests were added for the new endpoints or UI handlers in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5491828e04832f9f02b4ee1119f14c)